### PR TITLE
Change invalid hyphen numbers to > 1 instead of != 1

### DIFF
--- a/app/src/main/kotlin/com/illusion/checkfirm/common/util/Tools.kt
+++ b/app/src/main/kotlin/com/illusion/checkfirm/common/util/Tools.kt
@@ -111,8 +111,8 @@ object Tools {
     }
 
     private fun isValidModel(model: String): Boolean {
-        // Hyphen이 하나만 있는지 확인
-        if (model.count { it == '-' } != 1) {
+        // Hyphen > 1 is invalid. Japanese KDDI models have no hyphen
+        if (model.count { it == '-' } > 1) {
             return false
         }
 


### PR DESCRIPTION
Japanese au KDDI models (like SCG20 S23 Ultra) have no hyphens. No au models ever have a hyphen.

More info:
- https://samfw.com/firmware/SCG20/KDI
- https://github.com/KHwang9883/MobileModels/blob/master/brands/samsung_global_en.md